### PR TITLE
Enables configuring the output jar as an Artifact in other builds

### DIFF
--- a/src/main/scala/dasho/DashOKeys.scala
+++ b/src/main/scala/dasho/DashOKeys.scala
@@ -34,5 +34,5 @@ trait DashOKeys {
   lazy val dashOVersion = settingKey[String]("Version of DashO")
 
   // Tasks
-  lazy val protect = taskKey[Unit]("Protect jar using DashO")
+  lazy val protect = taskKey[File]("Protect jar using DashO")
 }

--- a/src/main/scala/dasho/DashOPlugin.scala
+++ b/src/main/scala/dasho/DashOPlugin.scala
@@ -67,13 +67,14 @@ object DashOPlugin extends AutoPlugin {
     val inputArtifactPath = (Keys.artifactPath in Keys.packageBin in Compile).value
     val baseName = inputArtifactPath.getAbsolutePath.split("\\.(?=[^.]+$)").head
     val configFile = new File(baseName + ".dox")
+    val protectedJar = new File(baseName + "-protected.jar")
 
     // Write DashO config
     log.info(s"Writing DashO config to $configFile")
     new DashOConfig(
       dashOVersion.value,
       inputArtifactPath,
-      new File(baseName + "-protected.jar"),
+      protectedJar,
       new File(baseName + "-dashOMapping.txt"),
       new File(baseName + "-dashOReport.txt"),
       classPaths).write(configFile)
@@ -81,6 +82,7 @@ object DashOPlugin extends AutoPlugin {
     // Run the DashO protection
     log.info("Protecting using DashO")
     runDashOJar(configFile, new File(dashOHomeSetting + "/DashOPro.jar"), log)
+    protectedJar
   }
 
   private def runDashOJar(configFile: File, dashOJar: File, log: sbt.util.Logger): Unit = {


### PR DESCRIPTION
Returning the protected jar as an Artifact allows other builds to publish protected jars.